### PR TITLE
Get default service account only if compute_sa isn't set

### DIFF
--- a/swarm_deployment_gcp/swarm.py
+++ b/swarm_deployment_gcp/swarm.py
@@ -66,7 +66,6 @@ class SwarmDeploymentGCPArgs:
         :param instance_count: Number of compute instances to have in the swarm
         :param generated_ssh_key_path: Storage path for the generated ssh key file.
         """
-        default_compute_sa = gcp.compute.get_default_service_account().email
         self.name = name
         self.docker_token_secret_name = docker_token_secret_name
         self.region = region or "europe-west2"
@@ -76,7 +75,7 @@ class SwarmDeploymentGCPArgs:
         if include_current_ip:
             current_ip = requests.get("https://ifconfig.me/ip").text.strip()
             self.allowed_ips = self.allowed_ips + [current_ip]
-        self.compute_sa = compute_sa or default_compute_sa
+        self.compute_sa = compute_sa or gcp.compute.get_default_service_account().email
         self.service_ports = service_ports or []
         self.machine_type = machine_type or "e2-micro"
         self.instance_image_id = instance_image_id or "ubuntu-os-cloud/ubuntu-2204-lts"


### PR DESCRIPTION
The swarm module uses the default service account for the instances if one isn't specified with `compute_sa`. This is currently done on initialisation, where the default service account is retrieved regardless of whether `compute_sa` is set, even if it isn't used. 

This is changed to only happen if `compute_sa` is not set, which is necessary for cases where the deploying account does not have access to get service accounts in the project