### PR TITLE
Startup Script and Configuration Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ The following network components are created:
 This module can be used by either importing the module into a pulumi program, 
 or by cloning and using this repository directly.
 
+### Prerequisites
+To use this module the following prerequisites must be met:
+* Python version 3.10+ installed
+* Pulumi version 3+
+* Google APIs enabled:
+  * Compute Engine
+  * Secret Manager
+* Service account to be used by compute instances (set by `compute_sa`), with `roles/secretmanager.admin` 
+to create and access the secrets for swarm initialisation
+
+
 ### Import module
 
 1. Create a pulumi program
@@ -69,7 +80,7 @@ Remaining configuration values are:
 *  `region`: Deployment region for resources (default: `"europe-west2"`)
 *  `subnet_cidr_range`: CIDR range for subnet (default: `"10.0.0.0/16"`)
 *  `ssh_pub_keys`:SSH keys to add to instances with format 'username: public-ssh-key' (default: Map containing generated "deployer" ssh key)
-*  `include_current_ip`: Whether to include the current deployers IP in allowed_ips (default: `false`)
+*  `include_current_ip`: Whether to include the current deployers IP in `allowed_ips` for ssh access to instances (default: true)
 *  `allowed_ips`: IPs with SSH access to instances and access to docker service ports 
 (default: Empty list, unless `include_current_ip` is true, where the list will contain the IP of the deployer)
 *  `compute_sa`: Service account used by the compute instances. Note this service account must have access to docker token secret
@@ -79,6 +90,7 @@ Remaining configuration values are:
 *  `instance_image_id`: Compute instance image id, with the format `"{project}/{image}"`, or `"{project}/{family}"` 
 (default: `"ubuntu-os-cloud/ubuntu-2204-lts"`)
 *  `instance_count`: Number of compute instances to have in the swarm (default: `3`)
+*  `generate_ssh_key`: Whether to generate `deployer` ssh key to allow access to instance (default `false`)
 *  `generated_ssh_key_path`: Storage path for the generated ssh private key file (default `"./deployer_ssh_key"`)
 
 

--- a/swarm_deployment_gcp/__main__.py
+++ b/swarm_deployment_gcp/__main__.py
@@ -11,6 +11,7 @@ def main():
     config_args = {
         "name": config.require("name"),
         "docker_token_secret_name": config.require("docker_token_secret_name"),
+        "docker_token_secret_user_managed": config.get_bool("docker_token_secret_user_managed"),
         "region": config.get("region"),
         "subnet_cidr_range": config.get("subnet_cidr_range"),
         "ssh_pub_keys": config.get_object("ssh_pub_keys"),

--- a/swarm_deployment_gcp/__main__.py
+++ b/swarm_deployment_gcp/__main__.py
@@ -21,6 +21,7 @@ def main():
         "machine_type": config.get("machine_type"),
         "instance_image_id": config.get("instance_image_id"),
         "instance_count": config.get_int("instance_count"),
+        "generate_ssh_key": config.get("generate_ssh_key"),
         "generated_ssh_key_path": config.get("generated_ssh_key_path")
     }
     swarm_deployment = SwarmDeploymentGCP(SwarmDeploymentGCPArgs(**config_args))

--- a/swarm_deployment_gcp/swarm.py
+++ b/swarm_deployment_gcp/swarm.py
@@ -30,6 +30,7 @@ class SwarmDeploymentGCPArgs:
         instance_image_id (str): Compute instance image id, with the format {project}/{family}, or {project}/{family}.
             Defaults to ubuntu-os-cloud/ubuntu-2204-lts
         instance_count (int): Number of compute instances to have in the swarm
+        generate_ssh_key (bool): Whether to generate deployer ssh keys for connecting to the instance
         generated_ssh_key_path (str): Storage path for the generated ssh key file.
 
     """
@@ -41,6 +42,7 @@ class SwarmDeploymentGCPArgs:
                  subnet_cidr_range: str,
                  ssh_pub_keys: dict[str, str],
                  include_current_ip: bool,
+                 generate_ssh_key: bool,
                  allowed_ips: list[str],
                  compute_sa: str,
                  service_ports: list[str],
@@ -56,6 +58,7 @@ class SwarmDeploymentGCPArgs:
         :param subnet_cidr_range: CIDR range for subnet
         :param ssh_pub_keys:SSH keys to add to instances with format 'username: public-ssh-key'.
         :param include_current_ip: Whether to include the current deployers IP in allowed_ips (default to true)
+        :param generate_ssh_key: Whether to generate deployer ssh keys for connecting to the instance (default to false)
         :param allowed_ips: IPs with SSH access to instances and access to docker service ports
         :param compute_sa: Service account used by the compute instances (must have access to docker token secret).
             Uses default compute service account by default
@@ -81,6 +84,7 @@ class SwarmDeploymentGCPArgs:
         self.machine_type = machine_type or "e2-micro"
         self.instance_image_id = instance_image_id or "ubuntu-os-cloud/ubuntu-2204-lts"
         self.instance_count = instance_count or 3
+        self.generate_ssh_key = generate_ssh_key or False
         self.generated_ssh_key_path = generated_ssh_key_path or "./deployer_ssh_key"
 
 
@@ -93,7 +97,7 @@ class SwarmDeploymentGCP(pulumi.ComponentResource):
 
     Attributes:
         args (SwarmDeploymentGCPArgs): Configuration arguments
-        swarm_network (SwarmNetwork): Network Infrastucture for the swarm cluster
+        swarm_network (SwarmNetwork): Network Infrastructure for the swarm cluster
         swarm_cluster (SwarmCluster): Computes instances comprising Docker Swarm cluster
     """
 
@@ -104,8 +108,9 @@ class SwarmDeploymentGCP(pulumi.ComponentResource):
         #                                     additional_secret_outputs=['private_key_openssh', 'private_key_pem']))
         self.args = args
         self.swarm_network = SwarmNetwork(opts=pulumi.ResourceOptions(parent=self), **vars(args))
-        self.deployer_ssh_key_public = self._create_deployer_ssh_keypair()
-        args.ssh_pub_keys['deployer'] = self.deployer_ssh_key_public
+        if args.generate_ssh_key:
+            self.deployer_ssh_key_public = self._create_deployer_ssh_keypair()
+            args.ssh_pub_keys['deployer'] = self.deployer_ssh_key_public
         self.swarm_cluster = SwarmCluster(subnet_id=self.swarm_network.instance_subnet_id,
                                           opts=pulumi.ResourceOptions(parent=self), **vars(args))
         # pulumi.export("ssh_keys", args.ssh_pub_keys)
@@ -114,7 +119,7 @@ class SwarmDeploymentGCP(pulumi.ComponentResource):
             pulumi.export(f"instance-{i}-external_ip", instance.network_interfaces[0]["access_configs"][0].nat_ip)
 
         self.register_outputs({
-            "deployer_ssh_key_public": self.deployer_ssh_key_public,
+            "deployer_ssh_key_public": getattr(self, "deployer_ssh_key_public", None),
             "swarm_cluster": self.swarm_cluster
         })
 
@@ -299,8 +304,8 @@ apt-get update && apt-get -y install docker.io
             },
             metadata_startup_script=startup_script.format(
                 swarm_setup=f"""
-gcloud secrets describe {docker_token_secret_name} > /dev/null 2>&1
 GCLOUD_COMMAND="gcloud secrets versions add"
+gcloud secrets describe {docker_token_secret_name} > /dev/null 2>&1
 if [ $? -ne 0 ]; then
   GCLOUD_COMMAND="gcloud secrets create"
 fi


### PR DESCRIPTION
* Includes the current IP in the firewall rule allow list by default ( to prevent all source IPs from being allowed)
* Update swarm_setup script in the compute instance startup script so that it checks if a secret exists, if it does it runs `gcloud secrets versions add`, and if it doesnt exist it will run `gcloud secrets create`. Beforehand it only added a version, so if the secret didn't exist all the nodes wouldn't join the cluster
* Add `generate_ssh_key` value to make generation of the deployer ssh key optional
* Improve documentation